### PR TITLE
Vanilla port

### DIFF
--- a/AIO_Client/AIO_Client.toc
+++ b/AIO_Client/AIO_Client.toc
@@ -6,8 +6,9 @@
 ## SavedVariablesPerCharacter: AIO_sv_char
 
 #dependencies
+lua_compat.lua
 Dep_LibWindow-1.1\LibStub.lua
-Dep_LibWindow-1.1\LibWindow-1.1\LibWindow-1.1.lua
+#Dep_LibWindow-1.1\LibWindow-1.1\LibWindow-1.1.lua
 Dep_Smallfolk\smallfolk.lua
 lualzw-zeros\lualzw.lua
 queue.lua

--- a/AIO_Client/Dep_LibWindow-1.1/LibStub.lua
+++ b/AIO_Client/Dep_LibWindow-1.1/LibStub.lua
@@ -3,12 +3,21 @@
 -- LibStub is hereby placed in the Public Domain
 -- Credits: Kaelten, Cladhaire, ckknight, Mikk, Ammo, Nevcairiel, joshborke
 local LIBSTUB_MAJOR, LIBSTUB_MINOR = "LibStub", 2  -- NEVER MAKE THIS AN SVN REVISION! IT NEEDS TO BE USABLE IN ALL REPOS!
-local LibStub = _G[LIBSTUB_MAJOR]
+local LibStub
+if getglobal then
+    LibStub = getglobal(LIBSTUB_MAJOR)
+else
+	LibStub = _G[LIBSTUB_MAJOR]
+end
 
 -- Check to see is this version of the stub is obsolete
 if not LibStub or LibStub.minor < LIBSTUB_MINOR then
 	LibStub = LibStub or {libs = {}, minors = {} }
-	_G[LIBSTUB_MAJOR] = LibStub
+	if setglobal then
+		setglobal(LIBSTUB_MAJOR, LibStub)
+	else
+		_G[LIBSTUB_MAJOR] = LibStub
+	end
 	LibStub.minor = LIBSTUB_MINOR
 	
 	-- LibStub:NewLibrary(major, minor)
@@ -35,7 +44,7 @@ if not LibStub or LibStub.minor < LIBSTUB_MINOR then
 	-- returns the library object if found
 	function LibStub:GetLibrary(major, silent)
 		if not self.libs[major] and not silent then
-			error(("Cannot find a library instance of %q."):format(tostring(major)), 2)
+			error(format("Cannot find a library instance of %q.", tostring(major)), 2)
 		end
 		return self.libs[major], self.minors[major]
 	end

--- a/AIO_Client/lua_compat.lua
+++ b/AIO_Client/lua_compat.lua
@@ -1,0 +1,42 @@
+-- library for compatibility between different wow lua versions
+-- this is used to provide a consistent interface for functions
+
+if AIO_LuaCompat ~= nil then
+    error("AIO_LuaCompat already defined")
+end
+AIO_LuaCompat = {}
+
+function AIO_LuaCompat.print(...)
+    -- create message by concatenating all arguments from last to first
+    -- and ignoring nils until the first non-nil value encountered
+    local msg = ""
+    local printedSomething = false
+    for i = arg.n, 1, -1 do
+        if printedSomething or arg[i] ~= nil then
+            msg = (i == 1 and "" or " ") .. tostring(arg[i]) .. msg
+            printedSomething = true
+        end
+    end
+    DEFAULT_CHAT_FRAME:AddMessage(msg)
+end
+-- setglobal("print", AIO_LuaCompat.print)
+
+local len
+if table.getn then
+	local getn = table.getn
+	local strlen = string.len
+	function len(t)
+		if type(t) == 'table' then
+			return getn(t)
+		end
+		if type(t) == 'string' then
+			return strlen(t)
+		end
+		error('len function does not support ' .. type(t))
+	end
+else
+	len = loadstring("function(t) return #t end")
+end
+AIO_LuaCompat.len = len
+
+AIO_LuaCompat.math_huge = math.huge or 1E+308 * 1E+308

--- a/AIO_Client/lualzw-zeros/lualzw.lua
+++ b/AIO_Client/lualzw-zeros/lualzw.lua
@@ -24,9 +24,9 @@ SOFTWARE.
 
 local char = string.char
 local type = type
-local select = select
 local sub = string.sub
 local tconcat = table.concat
+local length = AIO_LuaCompat.len
 
 local basedictcompress = {}
 local basedictdecompress = {}
@@ -53,7 +53,7 @@ local function compress(input)
     if type(input) ~= "string" then
         return nil, "string expected, got "..type(input)
     end
-    local len = #input
+    local len = length(input)
     if len <= 1 then
         return "u"..input
     end
@@ -74,7 +74,7 @@ local function compress(input)
                 return nil, "algorithm error, could not fetch word"
             end
             result[n] = write
-            resultlen = resultlen + #write
+            resultlen = resultlen + length(write)
             n = n+1
             if  len <= resultlen then
                 return "u"..input
@@ -86,7 +86,7 @@ local function compress(input)
         end
     end
     result[n] = basedictcompress[word] or dict[word]
-    resultlen = resultlen+#result[n]
+    resultlen = resultlen+length(result[n])
     n = n+1
     if  len <= resultlen then
         return "u"..input
@@ -112,7 +112,7 @@ local function decompress(input)
         return nil, "string expected, got "..type(input)
     end
 
-    if #input < 1 then
+    if length(input) < 1 then
         return nil, "invalid input - not a compressed string"
     end
 
@@ -123,7 +123,7 @@ local function decompress(input)
         return nil, "invalid input - not a compressed string"
     end
     input = sub(input, 2)
-    local len = #input
+    local len = length(input)
 
     if len < 2 then
         return nil, "invalid input - not a compressed string"

--- a/Examples/HelloWorld.lua
+++ b/Examples/HelloWorld.lua
@@ -2,8 +2,8 @@ local AIO = AIO or require("AIO")
 
 if AIO.AddAddon() then
     -- we are on server
-    print("Hello Server")
+    AIO.print("Hello Server")
 else
     -- we are on client
-    print("Hello Client")
+    AIO.print("Hello Client")
 end

--- a/Examples/KaevStatTest/Client.lua
+++ b/Examples/KaevStatTest/Client.lua
@@ -7,11 +7,18 @@ local MyHandlers = AIO.AddHandlers("Kaev", {})
 
 -- Attribute window
 local frameAttributes = CreateFrame("Frame", "frameAttributes", UIParent)
-frameAttributes:SetSize(200, 300)
+frameAttributes:SetWidth(200)
+frameAttributes:SetHeight(300)
 frameAttributes:SetMovable(true)
 frameAttributes:EnableMouse(true)
 frameAttributes:RegisterForDrag("LeftButton")
-frameAttributes:SetPoint("CENTER")
+frameAttributes:SetPoint("CENTER", nil)
+-- AchievementFrame doesnt exist on vanilla wow so we use a solid color instead
+local FrameTexture = frameAttributes:CreateTexture("FrameTexture", "BACKGROUND")
+FrameTexture:SetPoint("TOPLEFT", 5, -5)
+FrameTexture:SetPoint("BOTTOMRIGHT", -5, 5)
+-- brown rgba color
+FrameTexture:SetTexture(139/255,69/255,19/255, 1)
 frameAttributes:SetBackdrop(
 {
     bgFile = "Interface/AchievementFrame/UI-Achievement-Parchment-Horizontal",
@@ -20,20 +27,23 @@ frameAttributes:SetBackdrop(
     insets = { left = 5, right = 5, top = 5, bottom = 5 }
 })
 -- Drag & Drop
-frameAttributes:SetScript("OnDragStart", frameAttributes.StartMoving)
-frameAttributes:SetScript("OnHide", frameAttributes.StopMovingOrSizing)
-frameAttributes:SetScript("OnDragStop", frameAttributes.StopMovingOrSizing)
+frameAttributes:SetScript("OnShow", function(a1, a2) AIO.print("XX", this, frameAttributes, this == frameAttributes, "YY") end)
+frameAttributes:SetScript("OnDragStart", function() frameAttributes:StartMoving() end)
+frameAttributes:SetScript("OnHide", function() frameAttributes:StopMovingOrSizing() end)
+frameAttributes:SetScript("OnDragStop", function() frameAttributes:StopMovingOrSizing() end)
 frameAttributes:Hide()
 
 -- Close button
 local buttonAttributesClose = CreateFrame("Button", "buttonAttributesClose", frameAttributes, "UIPanelCloseButton")
 buttonAttributesClose:SetPoint("TOPRIGHT", -5, -5)
 buttonAttributesClose:EnableMouse(true)
-buttonAttributesClose:SetSize(27, 27)
+buttonAttributesClose:SetWidth(27)
+buttonAttributesClose:SetHeight(27)
 
 -- Title bar
 local frameAttributesTitleBar = CreateFrame("Frame", "frameAttributesTitleBar", frameAttributes, nil)
-frameAttributesTitleBar:SetSize(135, 25)
+frameAttributesTitleBar:SetWidth(135)
+frameAttributesTitleBar:SetHeight(25)
 frameAttributesTitleBar:SetBackdrop(
 {
     bgFile = "Interface/CHARACTERFRAME/UI-Party-Background",
@@ -47,30 +57,35 @@ frameAttributesTitleBar:SetPoint("TOP", 0, 9)
 
 local fontAttributesTitleText = frameAttributesTitleBar:CreateFontString("fontAttributesTitleText")
 fontAttributesTitleText:SetFont("Fonts\\FRIZQT__.TTF", 13)
-fontAttributesTitleText:SetSize(190, 5)
+fontAttributesTitleText:SetWidth(190)
+fontAttributesTitleText:SetHeight(5)
 fontAttributesTitleText:SetPoint("CENTER", 0, 0)
 fontAttributesTitleText:SetText("|cffFFC125Attribute Points|r")
 
 -- Attribute points left
 local fontAttributesPointsLeft = frameAttributes:CreateFontString("fontAttributesPointsLeft")
 fontAttributesPointsLeft:SetFont("Fonts\\FRIZQT__.TTF", 15)
-fontAttributesPointsLeft:SetSize(50, 5)
+fontAttributesPointsLeft:SetWidth(50)
+fontAttributesPointsLeft:SetHeight(5)
 fontAttributesPointsLeft:SetPoint("TOPLEFT", 107, -25)
 
 -- Strength
 local fontAttributesStrength = frameAttributes:CreateFontString("fontAttributesStrength")
 fontAttributesStrength:SetFont("Fonts\\FRIZQT__.TTF", 15)
-fontAttributesStrength:SetSize(137, 5)
+fontAttributesStrength:SetWidth(137)
+fontAttributesStrength:SetHeight(5)
 fontAttributesStrength:SetPoint("TOPLEFT", -20, -45)
 fontAttributesStrength:SetText("|cFF000000Strength|r")
 
 local fontAttributesStrengthValue = frameAttributes:CreateFontString("fontAttributesStrengthValue")
 fontAttributesStrengthValue:SetFont("Fonts\\FRIZQT__.TTF", 15)
-fontAttributesStrengthValue:SetSize(50, 5)
+fontAttributesStrengthValue:SetWidth(50)
+fontAttributesStrengthValue:SetHeight(5)
 fontAttributesStrengthValue:SetPoint("TOPLEFT", 107, -45)
 
 local buttonAttributesIncreaseStrength = CreateFrame("Button", "buttonAttributesIncreaseStrength", frameAttributes, nil)
-buttonAttributesIncreaseStrength:SetSize(20, 20)
+buttonAttributesIncreaseStrength:SetWidth(20)
+buttonAttributesIncreaseStrength:SetHeight(20)
 buttonAttributesIncreaseStrength:SetPoint("TOPLEFT", 144, -39)
 buttonAttributesIncreaseStrength:EnableMouse(true)
 buttonAttributesIncreaseStrength:SetNormalTexture("Interface/BUTTONS/UI-SpellbookIcon-NextPage-Up")
@@ -79,7 +94,8 @@ buttonAttributesIncreaseStrength:SetPushedTexture("Interface/BUTTONS/UI-Spellboo
 buttonAttributesIncreaseStrength:SetScript("OnMouseUp", function() AIO.Handle("Kaev", "AttributesIncrease", 1) end)
        
 local buttonAttributesDecreaseStrength = CreateFrame("Button", "buttonAttributesDecreaseStrength", frameAttributes, nil)
-buttonAttributesDecreaseStrength:SetSize(20, 20)
+buttonAttributesDecreaseStrength:SetWidth(20)
+buttonAttributesDecreaseStrength:SetHeight(20)
 buttonAttributesDecreaseStrength:SetPoint("TOPLEFT", 104, -39)
 buttonAttributesDecreaseStrength:EnableMouse(true)
 buttonAttributesDecreaseStrength:SetNormalTexture("Interface/BUTTONS/UI-SpellbookIcon-PrevPage-Up")
@@ -90,17 +106,20 @@ buttonAttributesDecreaseStrength:SetScript("OnMouseUp", function() AIO.Handle("K
 -- Agility
 local fontAttributesAgility = frameAttributes:CreateFontString("fontAttributesAgility")
 fontAttributesAgility:SetFont("Fonts\\FRIZQT__.TTF", 15)
-fontAttributesAgility:SetSize(137, 5)
+fontAttributesAgility:SetWidth(137)
+fontAttributesAgility:SetHeight(5)
 fontAttributesAgility:SetPoint("TOPLEFT", -20, -65)
 fontAttributesAgility:SetText("|cFF000000Agility|r")
 
 local fontAttributesAgilityValue = frameAttributes:CreateFontString("fontAttributesAgilityValue")
 fontAttributesAgilityValue:SetFont("Fonts\\FRIZQT__.TTF", 15)
-fontAttributesAgilityValue:SetSize(50, 5)
+fontAttributesAgilityValue:SetWidth(50)
+fontAttributesAgilityValue:SetHeight(5)
 fontAttributesAgilityValue:SetPoint("TOPLEFT", 107, -65)
 
 local buttonAttributesIncreaseAgility = CreateFrame("Button", "buttonAttributesIncreaseAgility", frameAttributes, nil)
-buttonAttributesIncreaseAgility:SetSize(20, 20)
+buttonAttributesIncreaseAgility:SetWidth(20)
+buttonAttributesIncreaseAgility:SetHeight(20)
 buttonAttributesIncreaseAgility:SetPoint("TOPLEFT", 144, -59)
 buttonAttributesIncreaseAgility:EnableMouse(true)
 buttonAttributesIncreaseAgility:SetNormalTexture("Interface/BUTTONS/UI-SpellbookIcon-NextPage-Up")
@@ -109,7 +128,8 @@ buttonAttributesIncreaseAgility:SetPushedTexture("Interface/BUTTONS/UI-Spellbook
 buttonAttributesIncreaseAgility:SetScript("OnMouseUp", function() AIO.Handle("Kaev", "AttributesIncrease", 2) end)
        
 local buttonAttributesDecreaseAgility = CreateFrame("Button", "buttonAttributesDecreaseAgility", frameAttributes, nil)
-buttonAttributesDecreaseAgility:SetSize(20, 20)
+buttonAttributesDecreaseAgility:SetWidth(20)
+buttonAttributesDecreaseAgility:SetHeight(20)
 buttonAttributesDecreaseAgility:SetPoint("TOPLEFT", 104, -59)
 buttonAttributesDecreaseAgility:EnableMouse(true)
 buttonAttributesDecreaseAgility:SetNormalTexture("Interface/BUTTONS/UI-SpellbookIcon-PrevPage-Up")
@@ -120,17 +140,20 @@ buttonAttributesDecreaseAgility:SetScript("OnMouseUp", function() AIO.Handle("Ka
 -- Stamina
 local fontAttributesStamina = frameAttributes:CreateFontString("fontAttributesStamina")
 fontAttributesStamina:SetFont("Fonts\\FRIZQT__.TTF", 15)
-fontAttributesStamina:SetSize(137, 5)
+fontAttributesStamina:SetWidth(137)
+fontAttributesStamina:SetHeight(5)
 fontAttributesStamina:SetPoint("TOPLEFT", -20, -85)
 fontAttributesStamina:SetText("|cFF000000Stamina|r")
 
 local fontAttributesStaminaValue = frameAttributes:CreateFontString("fontAttributesStaminaValue")
 fontAttributesStaminaValue:SetFont("Fonts\\FRIZQT__.TTF", 15)
-fontAttributesStaminaValue:SetSize(50, 5)
+fontAttributesStaminaValue:SetWidth(50)
+fontAttributesStaminaValue:SetHeight(5)
 fontAttributesStaminaValue:SetPoint("TOPLEFT", 107, -85)
 
 local buttonAttributesIncreaseStamina = CreateFrame("Button", "buttonAttributesIncreaseStamina", frameAttributes, nil)
-buttonAttributesIncreaseStamina:SetSize(20, 20)
+buttonAttributesIncreaseStamina:SetWidth(20)
+buttonAttributesIncreaseStamina:SetHeight(20)
 buttonAttributesIncreaseStamina:SetPoint("TOPLEFT", 144, -79)
 buttonAttributesIncreaseStamina:EnableMouse(true)
 buttonAttributesIncreaseStamina:SetNormalTexture("Interface/BUTTONS/UI-SpellbookIcon-NextPage-Up")
@@ -139,7 +162,8 @@ buttonAttributesIncreaseStamina:SetPushedTexture("Interface/BUTTONS/UI-Spellbook
 buttonAttributesIncreaseStamina:SetScript("OnMouseUp", function() AIO.Handle("Kaev", "AttributesIncrease", 3) end)
        
 local buttonAttributesDecreaseStamina = CreateFrame("Button", "buttonAttributesDecreaseStamina", frameAttributes, nil)
-buttonAttributesDecreaseStamina:SetSize(20, 20)
+buttonAttributesDecreaseStamina:SetWidth(20)
+buttonAttributesDecreaseStamina:SetHeight(20)
 buttonAttributesDecreaseStamina:SetPoint("TOPLEFT", 104, -79)
 buttonAttributesDecreaseStamina:EnableMouse(true)
 buttonAttributesDecreaseStamina:SetNormalTexture("Interface/BUTTONS/UI-SpellbookIcon-PrevPage-Up")
@@ -150,17 +174,20 @@ buttonAttributesDecreaseStamina:SetScript("OnMouseUp", function() AIO.Handle("Ka
 -- Intellect
 local fontAttributesIntellect = frameAttributes:CreateFontString("fontAttributesIntellect")
 fontAttributesIntellect:SetFont("Fonts\\FRIZQT__.TTF", 15)
-fontAttributesIntellect:SetSize(137, 5)
+fontAttributesIntellect:SetWidth(137)
+fontAttributesIntellect:SetHeight(5)
 fontAttributesIntellect:SetPoint("TOPLEFT", -20, -105)
 fontAttributesIntellect:SetText("|cFF000000Intellect|r")
 
 local fontAttributesIntellectValue = frameAttributes:CreateFontString("fontAttributesIntellectValue")
 fontAttributesIntellectValue:SetFont("Fonts\\FRIZQT__.TTF", 15)
-fontAttributesIntellectValue:SetSize(50, 5)
+fontAttributesIntellectValue:SetWidth(50)
+fontAttributesIntellectValue:SetHeight(5)
 fontAttributesIntellectValue:SetPoint("TOPLEFT", 107, -105)
 
 local buttonAttributesIncreaseIntellect = CreateFrame("Button", "buttonAttributesIncreaseIntellect", frameAttributes, nil)
-buttonAttributesIncreaseIntellect:SetSize(20, 20)
+buttonAttributesIncreaseIntellect:SetWidth(20)
+buttonAttributesIncreaseIntellect:SetHeight(20)
 buttonAttributesIncreaseIntellect:SetPoint("TOPLEFT", 144, -99)
 buttonAttributesIncreaseIntellect:EnableMouse(true)
 buttonAttributesIncreaseIntellect:SetNormalTexture("Interface/BUTTONS/UI-SpellbookIcon-NextPage-Up")
@@ -169,7 +196,8 @@ buttonAttributesIncreaseIntellect:SetPushedTexture("Interface/BUTTONS/UI-Spellbo
 buttonAttributesIncreaseIntellect:SetScript("OnMouseUp", function() AIO.Handle("Kaev", "AttributesIncrease", 4) end)
        
 local buttonAttributesDecreaseIntellect = CreateFrame("Button", "buttonAttributesDecreaseIntellect", frameAttributes, nil)
-buttonAttributesDecreaseIntellect:SetSize(20, 20)
+buttonAttributesDecreaseIntellect:SetWidth(20)
+buttonAttributesDecreaseIntellect:SetHeight(20)
 buttonAttributesDecreaseIntellect:SetPoint("TOPLEFT", 104, -99)
 buttonAttributesDecreaseIntellect:EnableMouse(true)
 buttonAttributesDecreaseIntellect:SetNormalTexture("Interface/BUTTONS/UI-SpellbookIcon-PrevPage-Up")
@@ -180,17 +208,20 @@ buttonAttributesDecreaseIntellect:SetScript("OnMouseUp", function() AIO.Handle("
 -- Spirit
 local fontAttributesSpirit = frameAttributes:CreateFontString("fontAttributesSpirit")
 fontAttributesSpirit:SetFont("Fonts\\FRIZQT__.TTF", 15)
-fontAttributesSpirit:SetSize(137, 5)
+fontAttributesSpirit:SetWidth(137)
+fontAttributesSpirit:SetHeight(5)
 fontAttributesSpirit:SetPoint("TOPLEFT", -20, -125)
 fontAttributesSpirit:SetText("|cFF000000Spirit|r")
 
 local fontAttributesSpiritValue = frameAttributes:CreateFontString("fontAttributesSpiritValue")
 fontAttributesSpiritValue:SetFont("Fonts\\FRIZQT__.TTF", 15)
-fontAttributesSpiritValue:SetSize(50, 5)
+fontAttributesSpiritValue:SetWidth(50)
+fontAttributesSpiritValue:SetHeight(5)
 fontAttributesSpiritValue:SetPoint("TOPLEFT", 107, -125)
 
 local buttonAttributesIncreaseSpirit = CreateFrame("Button", "buttonAttributesIncreaseSpirit", frameAttributes, nil)
-buttonAttributesIncreaseSpirit:SetSize(20, 20)
+buttonAttributesIncreaseSpirit:SetWidth(20)
+buttonAttributesIncreaseSpirit:SetHeight(20)
 buttonAttributesIncreaseSpirit:SetPoint("TOPLEFT", 144, -119)
 buttonAttributesIncreaseSpirit:EnableMouse(true)
 buttonAttributesIncreaseSpirit:SetNormalTexture("Interface/BUTTONS/UI-SpellbookIcon-NextPage-Up")
@@ -199,7 +230,8 @@ buttonAttributesIncreaseSpirit:SetPushedTexture("Interface/BUTTONS/UI-SpellbookI
 buttonAttributesIncreaseSpirit:SetScript("OnMouseUp", function() AIO.Handle("Kaev", "AttributesIncrease", 5) end)
        
 buttonAttributesDecreaseSpirit = CreateFrame("Button", "buttonAttributesDecreaseSpirit", frameAttributes, nil)
-buttonAttributesDecreaseSpirit:SetSize(20, 20)
+buttonAttributesDecreaseSpirit:SetWidth(20)
+buttonAttributesDecreaseSpirit:SetHeight(20)
 buttonAttributesDecreaseSpirit:SetPoint("TOPLEFT", 104, -119)
 buttonAttributesDecreaseSpirit:EnableMouse(true)
 buttonAttributesDecreaseSpirit:SetNormalTexture("Interface/BUTTONS/UI-SpellbookIcon-PrevPage-Up")

--- a/Examples/PersistentVariables_Client.lua
+++ b/Examples/PersistentVariables_Client.lua
@@ -16,4 +16,4 @@ AIO.AddSavedVar("PLAYER_STUFF")
 
 -- Then you store data to it or read data from it
 PLAYER_STUFF.var = PLAYER_STUFF.var+1
-print("This value should increment on reloads of UI:", PLAYER_STUFF.var)
+AIO.print("This value should increment on reloads of UI:", PLAYER_STUFF.var)

--- a/Examples/PingPong.lua
+++ b/Examples/PingPong.lua
@@ -25,7 +25,7 @@ else
     -- When we receive the PingPong message on client, print pong and the time it took to
     -- go from client to server to client.
     function HandlePingPong(player, msg)
-        print(tostring(msg), time()-senttime)
+        AIO.print(tostring(msg), time()-senttime)
     end
     
     -- just incase we are overwriting someone's function ..

--- a/Examples/TestWindow/ExampleClient.lua
+++ b/Examples/TestWindow/ExampleClient.lua
@@ -72,23 +72,33 @@ local MyHandlers = AIO.AddHandlers("AIOExample", {})
 -- Note that this code is executed on addon side - you can use any addon API function etc.
 
 -- Create the base frame.
-FrameTest = CreateFrame("Frame", "FrameTest", UIParent, "UIPanelDialogTemplate")
+FrameTest = CreateFrame("Frame", "FrameTest", UIParent, nil) -- "UIPanelDialogTemplate" -- doesnt exist in vanilla wow
 local frame = FrameTest
 
 -- Some basic method usage..
 -- Read the wow addon widget API for what each function does:
 -- http://wowwiki.wikia.com/Widget_API
-frame:SetSize(200, 200)
+frame:SetWidth(200)
+frame:SetHeight(200)
+local FrameTexture = frame:CreateTexture("FrameTexture")
+FrameTexture:SetAllPoints(frame)
+FrameTexture:SetTexture(0, 0, 0, 0.5)
 frame:RegisterForDrag("LeftButton")
-frame:SetPoint("CENTER")
+frame:SetPoint("CENTER", nil)
 frame:SetToplevel(true)
 frame:SetClampedToScreen(true)
 -- Enable dragging of frame
 frame:SetMovable(true)
 frame:EnableMouse(true)
-frame:SetScript("OnDragStart", frame.StartMoving)
-frame:SetScript("OnHide", frame.StopMovingOrSizing)
-frame:SetScript("OnDragStop", frame.StopMovingOrSizing)
+frame:SetScript("OnDragStart", function() frame:StartMoving() end)
+frame:SetScript("OnHide", function() frame:StopMovingOrSizing() end)
+frame:SetScript("OnDragStop", function() frame:StopMovingOrSizing() end)
+-- Add close button
+local closeButton = CreateFrame("Button", "CloseButton", frame, "UIPanelCloseButton")
+closeButton:SetWidth(30)
+closeButton:SetHeight(30)
+closeButton:SetPoint("TOPRIGHT", frame, "TOPRIGHT")
+closeButton:SetScript("OnClick", function() frame:Hide() end)
 
 -- This enables saving of the position of the frame over reload of the UI or restarting game
 AIO.SavePosition(frame)
@@ -101,7 +111,8 @@ end
 
 -- Creating an input:
 local input = CreateFrame("EditBox", "InputTest", frame, "InputBoxTemplate")
-input:SetSize(100, 30)
+input:SetWidth(100)
+input:SetHeight(30)
 input:SetAutoFocus(false)
 input:SetPoint("CENTER", frame, "CENTER", 0, 50)
 input:SetScript("OnEnterPressed", input.ClearFocus)
@@ -109,21 +120,23 @@ input:SetScript("OnEscapePressed", input.ClearFocus)
 
 -- Creating a slider:
 local slider = CreateFrame("Slider", "SlideTest", frame, "OptionsSliderTemplate")
-slider:SetSize(100, 17)
+slider:SetWidth(100)
+slider:SetHeight(17)
 slider:SetPoint("CENTER", frame, "CENTER", 0, -50)
 slider:SetValueStep(0.5)
 slider:SetMinMaxValues(0, 100)
 slider:SetValue(50)
 slider.tooltipText = 'This is the Tooltip hint'
-_G[slider:GetName() .."Text"]:SetText(50)
-slider:SetScript("OnValueChanged", function(self) _G[slider:GetName() .."Text"]:SetText(self:GetValue()) end)
-_G[slider:GetName().."High"]:Hide()
-_G[slider:GetName().."Low"]:Hide()
+AIO.getglobal(slider:GetName() .."Text"):SetText(50)
+slider:SetScript("OnValueChanged", function() AIO.getglobal(slider:GetName() .."Text"):SetText(slider:GetValue()) end)
+AIO.getglobal(slider:GetName().."High"):Hide()
+AIO.getglobal(slider:GetName().."Low"):Hide()
 slider:Show()
 
 -- Creating a child, a button:
 local button = CreateFrame("Button", "ButtonTest", frame)
-button:SetSize(100, 30)
+button:SetWidth(100)
+button:SetHeight(30)
 button:SetPoint("CENTER", frame, "CENTER")
 button:EnableMouse(true)
 -- Small script to clear the focus from input on click
@@ -144,7 +157,7 @@ button:SetText("Test")
 -- You can find all events for different frame types here: http://wowwiki.wikia.com/Widget_handlers
 -- Here I send a message to the server that executes the print handler
 -- See the ExampleServer.lua file for the server side print handler.
-local function OnClickButton(btn)
-    AIO.Handle("AIOExample", "Print", btn:GetName(), input:GetText(), slider:GetValue())
+local function OnClickButton()
+    AIO.Handle("AIOExample", "Print", button:GetName(), input:GetText(), slider:GetValue())
 end
 button:SetScript("OnClick", OnClickButton)


### PR DESCRIPTION
DONE:
- Messaging works
- Addon sending works
- Compression works
- Examples work
- Saved variables work
- Had to change server->client message length to 255 to prevent crashes
- sending message to multiple players in one call is now disabled, send the message to each one separately

TODO:
- Saving position does not work yet, LibWindow is disabled.
- There are debug prints and comments etc that need to be cleaned up
- The code is messy and should be cleaned up
- Client and server files are currently different
- Cores take in different params for the Whisper function. Need to pass in correct param based on core (guid vs player)
- Docs need to be updated to reflect new functions and changes
- Should test how drunkenness etc affects the messaging
- There are a few TODO comments that need to be fixed

Classic quirks:
- The client uses a custom flavor of Lua 5.0, while newer would use 5.1. Since we need to use old version here, it causes complications.
- Many functions do not exist: select, match, `#`, print, SetSize
  - equivalent functions can be defined by hand or some alternative needs to be used like SetWidth and SetHeight.
- Functions work differently: find, unpack, SetPoint
  - equivalent functions can be defined by hand
- Event arguments are passed through global variables called: event, this, arg1, arg2, arg3, ....
  - we need to check if we are on vanilla client and use vanilla args instead
- `_G` is not exposed, math.huge does not exist, global variables are not global and must be set with getglobal and setglobal
  - create functions and definitions for same purposes
- strings do not have methods
  - instead one must explicitly call `string.find(s)` instead of `s:find()`
- Addon messages cannot be sent as whisper
  - Instead use normal whisper and hide the messages from chat.
- Long comments using `[====[` syntax does not work
- varargs do not work in the same way
  - Some workarounds are to use tables and unpack or use fixed amount of parameters (ARGS_MAX)
- the key `n` in tables is reserved and should not be used.